### PR TITLE
Add Spring Boot MCP memory server skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,30 @@
-# SpringBootMCPServer
+# Spring Boot MCP Memory Server
+
+This project provides a simple Spring Boot implementation of an MCP (Model Context Protocol) server that stores conversation memories in PostgreSQL. The server exposes REST endpoints for creating and querying memory records.
+
+## Building
+
+Use Maven to build the project:
+
+```bash
+mvn clean package
+```
+
+## Running
+
+Provide a PostgreSQL database and configure the connection properties in `src/main/resources/application.properties`.
+
+Run the application with:
+
+```bash
+java -jar target/mcp-server-0.0.1-SNAPSHOT.jar
+```
+
+## API
+
+- `POST /memories` – Store a memory record. Example body:
+  ```json
+  { "user": "alice", "content": "hello" }
+  ```
+- `GET /memories?user=alice` – List memories for a user.
+- `GET /memories?search=hello` – Search memories by content.

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,47 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.example</groupId>
+    <artifactId>mcp-server</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    <name>Spring Boot MCP Server</name>
+    <description>Memory server using Spring Boot and Postgres</description>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.2.5</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+    <properties>
+        <java.version>17</java.version>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webflux</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/com/example/mcp/McpServerApplication.java
+++ b/src/main/java/com/example/mcp/McpServerApplication.java
@@ -1,0 +1,16 @@
+package com.example.mcp;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@SpringBootApplication
+public class McpServerApplication {
+
+    private static final Logger logger = LoggerFactory.getLogger(McpServerApplication.class);
+
+    public static void main(String[] args) {
+        SpringApplication.run(McpServerApplication.class, args);
+    }
+}

--- a/src/main/java/com/example/mcp/MemoryRecord.java
+++ b/src/main/java/com/example/mcp/MemoryRecord.java
@@ -1,0 +1,53 @@
+package com.example.mcp;
+
+import jakarta.persistence.*;
+import java.time.Instant;
+
+@Entity
+@Table(name = "memory_records")
+public class MemoryRecord {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String user;
+
+    @Column(columnDefinition = "jsonb", nullable = false)
+    private String content;
+
+    @Column(nullable = false)
+    private Instant createdAt = Instant.now();
+
+    public MemoryRecord() {}
+
+    public MemoryRecord(String user, String content) {
+        this.user = user;
+        this.content = content;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getUser() {
+        return user;
+    }
+
+    public void setUser(String user) {
+        this.user = user;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+}

--- a/src/main/java/com/example/mcp/MemoryRecordController.java
+++ b/src/main/java/com/example/mcp/MemoryRecordController.java
@@ -1,0 +1,41 @@
+package com.example.mcp;
+
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/memories")
+public class MemoryRecordController {
+
+    private final MemoryRecordService service;
+
+    public MemoryRecordController(MemoryRecordService service) {
+        this.service = service;
+    }
+
+    @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    public Mono<MemoryRecord> createMemory(@RequestBody MemoryRequest request) {
+        return Mono.fromSupplier(() -> service.save(request.user(), request.content()));
+    }
+
+    @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
+    public Flux<MemoryRecord> listMemories(@RequestParam(required = false) String user,
+                                           @RequestParam(required = false) String search) {
+        if (search != null && !search.isEmpty()) {
+            List<MemoryRecord> result = service.searchByContent(search);
+            return Flux.fromIterable(result);
+        }
+        if (user != null) {
+            List<MemoryRecord> result = service.findByUser(user);
+            return Flux.fromIterable(result);
+        }
+        List<MemoryRecord> all = service.searchByContent("");
+        return Flux.fromIterable(all);
+    }
+
+    public record MemoryRequest(String user, String content) {}
+}

--- a/src/main/java/com/example/mcp/MemoryRecordRepository.java
+++ b/src/main/java/com/example/mcp/MemoryRecordRepository.java
@@ -1,0 +1,15 @@
+package com.example.mcp;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface MemoryRecordRepository extends JpaRepository<MemoryRecord, Long> {
+
+    List<MemoryRecord> findByUser(String user);
+
+    @Query(value = "SELECT * FROM memory_records WHERE content::text ILIKE %:text%", nativeQuery = true)
+    List<MemoryRecord> searchByContent(@Param("text") String text);
+}

--- a/src/main/java/com/example/mcp/MemoryRecordService.java
+++ b/src/main/java/com/example/mcp/MemoryRecordService.java
@@ -1,0 +1,28 @@
+package com.example.mcp;
+
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class MemoryRecordService {
+
+    private final MemoryRecordRepository repository;
+
+    public MemoryRecordService(MemoryRecordRepository repository) {
+        this.repository = repository;
+    }
+
+    public MemoryRecord save(String user, String content) {
+        MemoryRecord record = new MemoryRecord(user, content);
+        return repository.save(record);
+    }
+
+    public List<MemoryRecord> findByUser(String user) {
+        return repository.findByUser(user);
+    }
+
+    public List<MemoryRecord> searchByContent(String text) {
+        return repository.searchByContent(text);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,10 @@
+spring.datasource.url=jdbc:postgresql://localhost:5432/memorydb
+spring.datasource.username=postgres
+spring.datasource.password=postgres
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
+spring.ai.mcp.server.name=webflux-mcp-server
+spring.ai.mcp.server.version=1.0.0
+spring.ai.mcp.server.type=ASYNC
+spring.ai.mcp.server.instructions=This reactive server stores conversation memories
+spring.ai.mcp.server.sse-message-endpoint=/mcp/messages

--- a/src/test/java/com/example/mcp/McpServerApplicationTests.java
+++ b/src/test/java/com/example/mcp/McpServerApplicationTests.java
@@ -1,0 +1,12 @@
+package com.example.mcp;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class McpServerApplicationTests {
+
+    @Test
+    void contextLoads() {
+    }
+}


### PR DESCRIPTION
## Summary
- create Maven build with Spring Boot and PostgreSQL
- add `MemoryRecord` entity with JSON content and user field
- create repository, service and controller for memory operations
- configure application properties for MCP server and datasource
- document build and API usage in README
- add a basic test class

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844f453ef8c832bb74f3078910c637e